### PR TITLE
document minPublicationDate and maxPublicationDate parameters

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -86,10 +86,6 @@ paths:
         - $ref: '#/parameters/relations'
         - $ref: '#/parameters/alwaysResolve'
         - $ref: '#/parameters/output'
-        - $ref: '#/parameters/minTimestamp'
-        - $ref: '#/parameters/maxTimestamp'
-        - $ref: '#/parameters/minPublicationDate'
-        - $ref: '#/parameters/maxPublicationDate'
       responses:
         '200':
           description: A successful response
@@ -104,6 +100,10 @@ paths:
         - $ref: '#/parameters/personAddress'
         - $ref: '#/parameters/birthDate'
         - $ref: '#/parameters/personId'
+        - $ref: '#/parameters/minTimestamp'
+        - $ref: '#/parameters/maxTimestamp'
+        - $ref: '#/parameters/minPublicationDate'
+        - $ref: '#/parameters/maxPublicationDate'
         - $ref: '#/parameters/sources'
         - $ref: '#/parameters/source'
         - $ref: '#/parameters/content'

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -56,6 +56,10 @@ paths:
         - $ref: '#/parameters/companyId'
         - $ref: '#/parameters/fuzzyMatch'
         - $ref: '#/parameters/registerKey'
+        - $ref: '#/parameters/minTimestamp'
+        - $ref: '#/parameters/maxTimestamp'
+        - $ref: '#/parameters/minPublicationDate'
+        - $ref: '#/parameters/maxPublicationDate'
         - $ref: '#/parameters/sources'
         - $ref: '#/parameters/source'
         - $ref: '#/parameters/content'
@@ -82,6 +86,10 @@ paths:
         - $ref: '#/parameters/relations'
         - $ref: '#/parameters/alwaysResolve'
         - $ref: '#/parameters/output'
+        - $ref: '#/parameters/minTimestamp'
+        - $ref: '#/parameters/maxTimestamp'
+        - $ref: '#/parameters/minPublicationDate'
+        - $ref: '#/parameters/maxPublicationDate'
       responses:
         '200':
           description: A successful response
@@ -118,30 +126,22 @@ paths:
           in: query
           required: false
           type: string
-        - name: minTimestamp
-          description: minimum datetime publication was added to the database
-          in: query
-          required: false
-          type: string
-          format: date-time
-        - name: maxTimestamp
-          description: maximum datetime publication was added to the database
-          in: query
-          required: false
-          type: string
-          format: date-time
         - name: minDate
-          description: DEPRECATED - please use minTimestamp instead
+          description: DEPRECATED - please use minTimestamp or minPublicationDate instead
           in: query
           required: false
           type: string
           format: date
         - name: maxDate
-          description: DEPRECATED - please use maxTimestamp instead
+          description: DEPRECATED - please use maxTimestamp or maxPublicationDate instead
           in: query
           required: false
           type: string
           format: date
+        - $ref: '#/parameters/minTimestamp'
+        - $ref: '#/parameters/maxTimestamp'
+        - $ref: '#/parameters/minPublicationDate'
+        - $ref: '#/parameters/maxPublicationDate'
         - $ref: '#/parameters/sources'
         - $ref: '#/parameters/source'
         - $ref: '#/parameters/content'
@@ -467,6 +467,34 @@ parameters:
     in: query
     required: false
     type: string
+  minPublicationDate:
+    name: minPublicationDate
+    description: minimum date publication was published on (by the source)
+    in: query
+    required: false
+    type: string
+    format: date
+  maxPublicationDate:
+    name: maxPublicationDate
+    description: maximum date publication was published on (by the source)
+    in: query
+    required: false
+    type: string
+    format: date
+  minTimestamp:
+    name: minTimestamp
+    description: minimum datetime publication was added to the database
+    in: query
+    required: false
+    type: string
+    format: date-time
+  maxTimestamp:
+    name: maxTimestamp
+    description: maximum datetime publication was added to the database
+    in: query
+    required: false
+    type: string
+    format: date-time
   sources:
     name: sources
     description: DEPRECATED (will be removed at some point of time)


### PR DESCRIPTION
closes northdata/northdata#3265, closes northdata/northdata#10168

@reezom I've also added the timestamp and publication date params to `company/v1/publications` and `user/v1/publications`. Some other parameters are supported via `ApiRequest.filterPublications` but not documented, and I'm not sure if it's intentional. LMK if you want to add or remove any from the documentation.